### PR TITLE
Added the constants you have to the actual defaults. Added timeout to API.

### DIFF
--- a/namecheap/resource_namecheap_record.go
+++ b/namecheap/resource_namecheap_record.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/adamdecaf/namecheap"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -12,8 +13,10 @@ import (
 // We need a mutex here because of the underlying api
 var mutex = &sync.Mutex{}
 
-const ncDefaultTTL int = 1800
+// This is the "Auto" TTL setting in Namecheap
+const ncDefaultTTL int = 1799
 const ncDefaultMXPref int = 10
+const ncDefaultTimeout time.Duration = 30
 
 func resourceNameCheapRecord() *schema.Resource {
 	return &schema.Resource{
@@ -21,6 +24,13 @@ func resourceNameCheapRecord() *schema.Resource {
 		Update: resourceNameCheapRecordUpdate,
 		Read:   resourceNameCheapRecordRead,
 		Delete: resourceNameCheapRecordDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(ncDefaultTimeout * time.Second),
+			Update: schema.DefaultTimeout(ncDefaultTimeout * time.Second),
+			Read:   schema.DefaultTimeout(ncDefaultTimeout * time.Second),
+			Delete: schema.DefaultTimeout(ncDefaultTimeout * time.Second),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain": &schema.Schema{
@@ -42,12 +52,12 @@ func resourceNameCheapRecord() *schema.Resource {
 			"mx_pref": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  10,
+				Default:  ncDefaultMXPref,
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1800,
+				Default:  ncDefaultTTL,
 			},
 			"hostname": &schema.Schema{
 				Type:     schema.TypeString,

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+make build
+mv /Users/ogp/go-workspace/bin/terraform-provider-namecheap ~/.terraform.d/plugins/terraform-provider-namecheap
+chmod +x ~/.terraform.d/plugins/terraform-provider-namecheap


### PR DESCRIPTION
* Added the consts for ttl, mx pref, and timeout default to the schema default value.
* Added the timeout feature on Terraform to 30 seconds for API calls to NC. 
* Added a build and install script but debating on removing if owner wants to from PR.