### PR TITLE
Backoff/Retry Logic for Namecheap Domain Record

### DIFF
--- a/namecheap/resource_namecheap_record.go
+++ b/namecheap/resource_namecheap_record.go
@@ -2,7 +2,9 @@ package namecheap
 
 import (
 	"fmt"
+	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +19,8 @@ var mutex = &sync.Mutex{}
 const ncDefaultTTL int = 1799
 const ncDefaultMXPref int = 10
 const ncDefaultTimeout time.Duration = 30
+const ncMaxThrottleRetry int = 60
+const ncBackoffMultiplier int = 2
 
 func resourceNameCheapRecord() *schema.Resource {
 	return &schema.Resource{
@@ -79,14 +83,33 @@ func resourceNameCheapRecordCreate(d *schema.ResourceData, meta interface{}) err
 		TTL:        d.Get("ttl").(int),
 	}
 
-	_, err := client.AddRecord(d.Get("domain").(string), &record)
+	apiThrottleBackoffTime := 2
 
-	if err != nil {
-		mutex.Unlock()
-		return fmt.Errorf("Failed to create namecheap Record: %s", err)
+	for {
+		_, err := client.AddRecord(d.Get("domain").(string), &record)
+		if err != nil {
+			log.Printf("[TRACE] Err: %v", err.Error())
+
+			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
+				log.Printf("[WARN] Bad Namecheap API response received, backing off for %d seconds...",
+					apiThrottleBackoffTime)
+				time.Sleep(time.Duration(apiThrottleBackoffTime) * time.Second)
+				apiThrottleBackoffTime = apiThrottleBackoffTime * ncBackoffMultiplier
+				if apiThrottleBackoffTime > ncMaxThrottleRetry {
+					log.Printf("[ERROR] API Retry Limit Reached. Couldn't find namecheap record: %v", err)
+					break
+				}
+				continue
+			} else {
+				log.Printf("[INFO] Error")
+			}
+			mutex.Unlock()
+			return fmt.Errorf("Failed to create namecheap Record: %s", err)
+		}
+		hashId := client.CreateHash(&record)
+		d.SetId(strconv.Itoa(hashId))
+		break
 	}
-	hashId := client.CreateHash(&record)
-	d.SetId(strconv.Itoa(hashId))
 
 	mutex.Unlock()
 	return resourceNameCheapRecordRead(d, meta)
@@ -109,13 +132,33 @@ func resourceNameCheapRecordUpdate(d *schema.ResourceData, meta interface{}) err
 		MXPref:     d.Get("mx_pref").(int),
 		TTL:        d.Get("ttl").(int),
 	}
-	err = client.UpdateRecord(domain, hashId, &record)
-	if err != nil {
-		mutex.Unlock()
-		return fmt.Errorf("Failed to update namecheap record: %s", err)
+
+	apiThrottleBackoffTime := 2
+
+	for {
+		err = client.UpdateRecord(domain, hashId, &record)
+		if err != nil {
+			log.Printf("[TRACE] Err: %v", err.Error())
+
+			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
+				log.Printf("[WARN] Bad Namecheap API response received, backing off for %v seconds...",
+					apiThrottleBackoffTime)
+				time.Sleep(time.Duration(apiThrottleBackoffTime) * time.Second)
+				apiThrottleBackoffTime = apiThrottleBackoffTime * ncBackoffMultiplier
+				if apiThrottleBackoffTime > ncMaxThrottleRetry {
+					log.Printf("[ERROR] API Retry Limit Reached. Couldn't find namecheap record: %v", err)
+					break
+				}
+				continue
+			}
+			mutex.Unlock()
+			log.Printf("[ERROR] Failed to update namecheap record: %s", err)
+			break
+		}
+		newHashId := client.CreateHash(&record)
+		d.SetId(strconv.Itoa(newHashId))
+		break
 	}
-	newHashId := client.CreateHash(&record)
-	d.SetId(strconv.Itoa(newHashId))
 
 	mutex.Unlock()
 	return resourceNameCheapRecordRead(d, meta)
@@ -132,21 +175,41 @@ func resourceNameCheapRecordRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Failed to parse id: %s", err)
 	}
 
-	record, err := client.ReadRecord(domain, hashId)
-	if err != nil {
-		return fmt.Errorf("Couldn't find namecheap record: %s", err)
-	}
-	d.Set("name", record.Name)
-	d.Set("type", record.RecordType)
-	d.Set("address", record.Address)
-	d.Set("mx_pref", record.MXPref)
-	d.Set("ttl", record.TTL)
+	apiThrottleBackoffTime := 2
 
-	if record.Name == "" {
-		d.Set("hostname", d.Get("domain").(string))
-	} else {
-		d.Set("hostname", fmt.Sprintf("%s.%s", record.Name, d.Get("domain").(string)))
+	for {
+		record, err := client.ReadRecord(domain, hashId)
+		if err != nil {
+			log.Printf("[TRACE] Record: %v", record)
+			log.Printf("[TRACE] Err: %v", err.Error())
+			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
+				log.Printf("[WARN] Bad Namecheap API response received, backing off for %v seconds...",
+					apiThrottleBackoffTime)
+				time.Sleep(time.Duration(apiThrottleBackoffTime) * time.Second)
+				apiThrottleBackoffTime = apiThrottleBackoffTime * ncBackoffMultiplier
+				if apiThrottleBackoffTime > ncMaxThrottleRetry {
+					log.Printf("[ERROR] API Retry Limit Reached. Couldn't find namecheap record: %v", err)
+					break
+				}
+				continue
+			}
+			return fmt.Errorf("Couldn't find namecheap record: %s", err)
+		}
+
+		d.Set("name", record.Name)
+		d.Set("type", record.RecordType)
+		d.Set("address", record.Address)
+		d.Set("mx_pref", record.MXPref)
+		d.Set("ttl", record.TTL)
+
+		if record.Name == "" {
+			d.Set("hostname", d.Get("domain").(string))
+		} else {
+			d.Set("hostname", fmt.Sprintf("%s.%s", record.Name, d.Get("domain").(string)))
+		}
+		break
 	}
+
 	return nil
 }
 
@@ -160,10 +223,29 @@ func resourceNameCheapRecordDelete(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return fmt.Errorf("Failed to parse id: %s", err)
 	}
-	err = client.DeleteRecord(domain, hashId)
 
-	if err != nil {
-		return fmt.Errorf("Failed to delete namecheap record: %s", err)
+	apiThrottleBackoffTime := 2
+
+	for {
+		err = client.DeleteRecord(domain, hashId)
+		if err != nil {
+			log.Printf("[TRACE] Err: %v", err.Error())
+
+			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
+				log.Printf("[WARN] Bad Namecheap API response received, backing off for %d seconds...",
+					apiThrottleBackoffTime)
+				time.Sleep(time.Duration(apiThrottleBackoffTime) * time.Second)
+				apiThrottleBackoffTime = apiThrottleBackoffTime * ncBackoffMultiplier
+				if apiThrottleBackoffTime > ncMaxThrottleRetry {
+					log.Printf("[ERROR] API Retry Limit Reached. Bailing: %v", err)
+					break
+				}
+				continue
+			}
+			return fmt.Errorf("Failed to delete namecheap record: %s", err)
+		}
+		break
 	}
+
 	return nil
 }

--- a/namecheap/resource_namecheap_record.go
+++ b/namecheap/resource_namecheap_record.go
@@ -88,7 +88,7 @@ func resourceNameCheapRecordCreate(d *schema.ResourceData, meta interface{}) err
 	for {
 		_, err := client.AddRecord(d.Get("domain").(string), &record)
 		if err != nil {
-			log.Printf("[TRACE] Err: %v", err.Error())
+			log.Printf("[INFO] Err: %v", err.Error())
 
 			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
 				log.Printf("[WARN] Bad Namecheap API response received, backing off for %d seconds...",
@@ -100,10 +100,7 @@ func resourceNameCheapRecordCreate(d *schema.ResourceData, meta interface{}) err
 					break
 				}
 				continue
-			} else {
-				log.Printf("[INFO] Error")
 			}
-			mutex.Unlock()
 			return fmt.Errorf("Failed to create namecheap Record: %s", err)
 		}
 		hashId := client.CreateHash(&record)
@@ -138,7 +135,7 @@ func resourceNameCheapRecordUpdate(d *schema.ResourceData, meta interface{}) err
 	for {
 		err = client.UpdateRecord(domain, hashId, &record)
 		if err != nil {
-			log.Printf("[TRACE] Err: %v", err.Error())
+			log.Printf("[INFO] Err: %v", err.Error())
 
 			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
 				log.Printf("[WARN] Bad Namecheap API response received, backing off for %v seconds...",
@@ -151,7 +148,6 @@ func resourceNameCheapRecordUpdate(d *schema.ResourceData, meta interface{}) err
 				}
 				continue
 			}
-			mutex.Unlock()
 			log.Printf("[ERROR] Failed to update namecheap record: %s", err)
 			break
 		}
@@ -181,7 +177,7 @@ func resourceNameCheapRecordRead(d *schema.ResourceData, meta interface{}) error
 		record, err := client.ReadRecord(domain, hashId)
 		if err != nil {
 			log.Printf("[TRACE] Record: %v", record)
-			log.Printf("[TRACE] Err: %v", err.Error())
+			log.Printf("[INFO] Err: %v", err.Error())
 			if strings.Contains(err.Error(), "expected element type <ApiResponse> but have <html>") {
 				log.Printf("[WARN] Bad Namecheap API response received, backing off for %v seconds...",
 					apiThrottleBackoffTime)


### PR DESCRIPTION
Added max throttle and backoff const plus backoff logic for namecheap API calls. Crude string checking at the moment for the throttling response but it seems to work really well after testing it with my production stack.

Here are some logs I got from one of my production runs (Take note of the parts that say "Bad Namecheap API response received, backing off for X seconds..."):

```


2019/01/31 18:53:33 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019-01-31T18:53:35.741-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:35 [TRACE] Record: <nil>
2019-01-31T18:53:35.741-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:35 [TRACE] Err: expected element type <ApiResponse> but have <html>
2019-01-31T18:53:35.741-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:35 [WARN] Bad Namecheap API response received, backing off for 2 seconds...
2019/01/31 18:53:36 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019-01-31T18:53:37.906-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:37 [TRACE] Record: <nil>
2019-01-31T18:53:37.906-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:37 [TRACE] Err: expected element type <ApiResponse> but have <html>
2019-01-31T18:53:37.906-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:37 [WARN] Bad Namecheap API response received, backing off for 4 seconds...
2019/01/31 18:53:38 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019/01/31 18:53:41 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019-01-31T18:53:42.060-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:42 [TRACE] Record: <nil>
2019-01-31T18:53:42.060-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:42 [TRACE] Err: expected element type <ApiResponse> but have <html>
2019-01-31T18:53:42.060-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:42 [WARN] Bad Namecheap API response received, backing off for 8 seconds...
2019/01/31 18:53:43 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019/01/31 18:53:46 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019/01/31 18:53:48 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019-01-31T18:53:50.219-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:50 [TRACE] Record: <nil>
2019-01-31T18:53:50.219-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:50 [TRACE] Err: expected element type <ApiResponse> but have <html>
2019-01-31T18:53:50.219-0800 [DEBUG] plugin.terraform-provider-namecheap: 2019/01/31 18:53:50 [WARN] Bad Namecheap API response received, backing off for 16 seconds...
2019/01/31 18:53:51 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019/01/31 18:53:53 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019/01/31 18:53:56 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019/01/31 18:53:58 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019/01/31 18:54:01 [TRACE] dag/walk: vertex "root", waiting for: "provider.namecheap (close)"
2019/01/31 18:54:03 [TRACE] dag/walk: vertex "provider.namecheap (close)", waiting for: "namecheap_record.www-sincitymob-com"
2019/01/31 18:54:06 [TRACE] root: eval: *terraform.EvalWriteState

```