### PR TITLE
Update Mac installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ wget -O ~/.terraform.d/plugins/terraform-provider-namecheap https://github.com
 ```bash
 $ mkdir -p ~/.terraform.d/plugins/
 $ curl -L https://github.com/adamdecaf/terraform-provider-namecheap/releases/download/1.5.0/terraform-provider-namecheap-osx-amd64 > ~/.terraform.d/plugins/terraform-provider-namecheap
-$ chmod +x ~/.terraform.d/plugins/terraform-provider-namecheap
+$ chmod +x ~/.terraform.d/plugins/terraform-provider-namecheap_v1.5.0
 ```
 
 Then inside a Terraform file within your project (Ex. `providers.tf`):


### PR DESCRIPTION
Following https://www.terraform.io/docs/configuration/providers.html#third-party-plugins it seems necessary to hint at the provider version in the binary name.